### PR TITLE
Rails3 - Changing gems repo to its https equivalent

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ Getting CommunityEngine Running
 
 		source 'http://rubygems.org'
 
-                gem 'community_engine', '1.9.9', :git => 'https://github.com/bborn/communityengine.git', :branch => 'rails3'
+		gem 'community_engine', '1.9.9', :git => 'git://github.com/bborn/rails.git', :branch => 'omniauth'
 
 		# Bundle edge Rails
 		gem 'rails', :git => 'git://github.com/bborn/rails.git'


### PR DESCRIPTION
Makes life easier to people behind a firewall.
