### PR TITLE
Properly set the current user and current session when creating a session

### DIFF
--- a/lib/community_engine/authenticated_system.rb
+++ b/lib/community_engine/authenticated_system.rb
@@ -23,7 +23,8 @@ module AuthenticatedSystem
     # Create a user session without credentials.
     def current_user=(user)
       return if current_user # Use act_as_user= to switch to another user account
-      UserSession.create(user, true)
+      @current_user_session = UserSession.create(user, true)
+      @current_user = @current_user_session.record
     end
 
     # Set session to another user.  Only available to admins


### PR DESCRIPTION
When creating a user session without credentials the instance variables for the user session and the user were not set. This causes current_user to return nil.
