### PR TITLE
Fix so tags handle utf8

### DIFF
--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -142,7 +142,7 @@ module BaseHelper
             end
             title += " (#{:related_tags.l}: #{@related_tags.join(', ')})" if @related_tags
             title += divider + app_base    
-            @canonical_url = tag_url(URI.escape(@tags_raw, /[\/.?#]/)) if @tags_raw
+            @canonical_url = tag_url(URI.escape(URI.escape(@tags_raw), /[\/.?#]/)) if @tags_raw
           else
             title = "Showing tags #{divider} #{app_base} #{tagline}"
           end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,7 +15,8 @@ class Tag < ActiveRecord::Base
   end
       
   def to_param
-    URI.escape(self.name, /[\/.?#]/)
+    # First call to escape function is to handle utf-8 characters
+    URI.escape(URI.escape(self.name), /[\/.?#]/)
   end
   
   def related_tags(limit = 10)

--- a/app/views/activities/index.html.haml
+++ b/app/views/activities/index.html.haml
@@ -11,6 +11,6 @@
     -box do 
       %h3= :tags.l
       - tag_cloud @popular_tags, %w(nube1 nube2 nube3 nube4 nube5) do |tag, css_class|
-        = link_to tag.name, tag_path(URI.escape(tag.name.to_s, /[\/.?#]/)), :class => css_class
+        = link_to tag.name, tag_path(tag.to_param), :class => css_class
       %h6.all=link_to :all_tags.l, tags_path
 

--- a/app/views/shared/_footer_content.html.haml
+++ b/app/views/shared/_footer_content.html.haml
@@ -9,5 +9,5 @@
   -box do 
     %h3=:tags.l
     - tag_cloud @popular_tags, %w(nube1 nube2 nube3 nube4 nube5) do |tag, css_class|
-      = link_to tag.name, tag_path(URI.escape(tag.name, /[\/.?#]/)), :class => css_class
+      = link_to tag.name, tag_path(tag.to_param), :class => css_class
     %h6.all=link_to :all_tags.l, tags_path

--- a/app/views/tags/index.html.haml
+++ b/app/views/tags/index.html.haml
@@ -22,4 +22,4 @@
     -box do
       %h3= :browse_content_by_tags.l
       -tag_cloud @tags, %w(css1 css2 css3 css4) do |tag, css_class|
-        =link_to tag.name, tag_url(URI.escape(tag.name.to_s, /[\/.?#]/)), :class => css_class
+        =link_to tag.name, tag_url(tag.to_param), :class => css_class

--- a/test/fixtures/taggings.yml
+++ b/test/fixtures/taggings.yml
@@ -12,4 +12,14 @@ yahoo_clipping_tagged_misc:
   id: 3
   tag_id: 2
   taggable_id: 2
-  taggable_type: Clipping  
+  taggable_type: Clipping
+another_pic_tagged_special_characters:
+  id: 4
+  tag_id: 4
+  taggable_id: 2
+  taggable_type: Photo
+google_clipping_tagged_related:
+  id: 5
+  tag_id: 5
+  taggable_id: 1
+  taggable_type: Clipping

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -9,3 +9,11 @@ misc:
 extra:
   id: 3
   name: Extra
+
+special_characters:
+  id: 4
+  name: Svår
+
+related_to_misc:
+  id: 5
+  name: Related

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -14,6 +14,11 @@ class TagsControllerTest < ActionController::TestCase
    assert_response :success
    assert assigns(:photos).include?(photos(:library_pic))
   end
+
+  def test_should_show_special_character_tag
+    get :show, :id => tags(:special_characters).name
+    assert_response :success
+  end
   
   def test_should_show_tag_with_type
    %w(posts users clippings photos).each do |type|

--- a/test/testapp/db/schema.rb
+++ b/test/testapp/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -10,13 +10,13 @@ class TagTest < ActiveSupport::TestCase
   
   test "should get popular tags of one type" do
     popular = Tag.popular(20, 'clipping')
-    assert_equal popular.to_a.size, 1
+    assert_equal popular.to_a.size, 2
     assert_equal popular.first['count'], 2
   end
   
   test "should get related tags" do
     related = tags(:misc).related_tags
-    assert_equal(related, [tags(:general)])
+    assert_equal(related, [tags(:related_to_misc)])
   end
   
 end


### PR DESCRIPTION
This is an attempt to fix issue 35, problems with utf8 tags. I added some tests and made an attempt to fix, calling URI.Escape with only one argument to first escape the utf-8 and then run the previous escaping sequence.

I ran into another issue while doing this, reported as issue #38. So there is one test failing due to that issue.
