### PR TITLE
update Rails to 3.1.3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ Information at: [http://www.communityengine.org](http://www.communityengine.org)
 
 Requirements:
 
-	- RAILS VERSION 3.1.2
+	- RAILS VERSION 3.1.3
 
 Getting CommunityEngine Running
 --------------------------------

--- a/community_engine.gemspec
+++ b/community_engine.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n") rescue ''
   s.test_files  = `git ls-files -- {test}/*`.split("\n")  
   
-  s.add_dependency(%q<rails>, ["= 3.1.2"])
+  s.add_dependency(%q<rails>, ["= 3.1.3"])
   s.add_dependency(%q<rack>, ["= 1.3.5"])
   s.add_dependency(%q<arel>, ["= 2.2.1"])
   s.add_dependency(%q<authlogic>, [">= 0"])


### PR DESCRIPTION
Version 3.1.3 fixes some regressions that came up with 3.1.2.
See http://weblog.rubyonrails.org/2011/11/20/rails-3-1-3-has-been-released for details
