### PR TITLE
Activate user when they click on a password reset link we email them

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -22,6 +22,10 @@ class PasswordResetsController < BaseController
   end
 
   def edit
+    # If the user is clicking on a 'reset password' link we emailed him, he's confirming that email
+    if !@user.active?
+      @user.activate
+    end
   end
 
   def update


### PR DESCRIPTION
Password resets for users who have not activated their accounts are a de-facto email confirmation. We can save them a step and activate their account here.
