### PR TITLE
Rails3 - <img>-tag in next link in photos/show.html.haml is not html_safe

### DIFF
--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -14,7 +14,7 @@
       -box :class => "photo_nav alt" do
         = link_to "<img src='#{@previous.photo.url(:thumb)}' /><br />&laquo; ".html_safe + :previous.l, user_photo_path(@user, @previous), :class => 'left' if @previous
         
-        = link_to "<img src='#{@next.photo.url(:thumb)}' /><br />" + :next.l + "&raquo;".html_safe, user_photo_path(@user, @next), :class => 'right' if @next
+        = link_to "<img src='#{@next.photo.url(:thumb)}' /><br />".html_safe + :next.l + "&raquo;".html_safe, user_photo_path(@user, @next), :class => 'right' if @next
 
     - if @related.any?
       -box :class => "alt" do 


### PR DESCRIPTION
In a photos show.html.haml the link to the next photo (in photo navigation) is not html_safe and therefore appears as escaped html in the front-end.
