### PR TITLE
Do not offer to send a message to me if I'm visiting my own profile page

### DIFF
--- a/app/views/users/_profile_user_info_sidebar.html.haml
+++ b/app/views/users/_profile_user_info_sidebar.html.haml
@@ -45,6 +45,6 @@
         %li.tags= "#{:my_tags.l}: #{@user.tags.collect{|t| link_to t.name, tag_url(t) }.join(", ")}".html_safe
       - if @user.metro_area
         %li.geo= link_to( @user.full_location, users_path(:metro_area_id => @user.metro_area_id, :state_id => @user.state_id, :country_id => @user.country_id ) ) 
-      - if current_user && user != current_user
+      - if current_user && @user != current_user
         %li.compose= link_to(:send_me_a_message.l, new_user_message_path(current_user, :to=>@user))
   .clear


### PR DESCRIPTION
When I visit my own profile page, community engine offers to send a message to myself. (Un-)Fortunately I get an error message later in the message dialog and cannot send the message. However, we should not allow the user to send a message to himself in the first place.
