### PR TITLE
Redirect after login does not always work

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -11,6 +11,7 @@ class BaseController < ApplicationController
   helper_method :commentable_url
   before_filter :initialize_header_tabs
   before_filter :initialize_admin_tabs
+  before_filter :store_location
 
   caches_action :site_index, :footer_content, :if => Proc.new{|c| c.cache_action? }
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 # This controller handles the login/logout function of the site.  
 class SessionsController < BaseController
 
+  skip_before_filter :store_location, :only => [:new, :create]
+
   def index
     redirect_to :action => "new"
   end  
@@ -27,6 +29,7 @@ class SessionsController < BaseController
 
   def destroy
     current_user_session.destroy
+    reset_session
     flash[:notice] = :youve_been_logged_out_hope_you_come_back_soon.l
     redirect_to new_session_path
   end

--- a/lib/community_engine/authenticated_system.rb
+++ b/lib/community_engine/authenticated_system.rb
@@ -131,7 +131,6 @@ module AuthenticatedSystem
     #   skip_before_filter :login_required
     #
     def login_required
-      store_location
       logged_in? && authorized? ? true : access_denied
     end
 


### PR DESCRIPTION
The before_filter, login_required calls store_location. However, if you don't need login_required (because anonymous access is fine) you will be redirected to the last page which used the login_required filter. This can be confusing, but not problematic. However, if the last request was an update request, this URL is stored as part of the session, which means you may update a model many times unintentionally. Further, session[:return_to] is not cleared on log out. This means that if a user logs out and another user logs in using the same browser they may be redirected to same page they never should have been redirected to.

I've attached a patch which attempts to resolve these issues. However, I'm not sure if this is the best way to resolve this particular issue but at least I've tested it and know it works.
