### PR TITLE
Event datetime selectors

### DIFF
--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -10,10 +10,10 @@
     = f.text_area :description, :size => "69x10", :class => "rich_text_editor"
     
     %label= :start_time.l
-    = f.date_select :start_time, :time => true 
+    = f.datetime_select :start_time
     
     %label= :end_time.l
-    = f.date_select :end_time, :time => true 
+    = f.datetime_select :end_time
 
     %label
       = f.check_box :allow_rsvp

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -10,9 +10,9 @@
     = f.text_area :description, :size => "69x10", :class => "rich_text_editor"
     
     %label= :start_time.l
-    = f.date_select :start_time, :time => true 
+    = f.datetime_select :start_time
     %label= :end_time.l
-    = f.date_select :end_time, :time => true 
+    = f.datetime_select :end_time
 
     %label
       = f.check_box :allow_rsvp


### PR DESCRIPTION
It looks like date_select does not support a :time option.  Thus the events#new and events#edit were only allowing users to select dates, not time.

This allows users to select date and time.

Sorry about that other request, please disregard it.

Regards,
Josh
