### PR TITLE
Fix for mass assignment error on db:migrate

### DIFF
--- a/db/migrate/008_add_friendship_statuses.rb
+++ b/db/migrate/008_add_friendship_statuses.rb
@@ -1,8 +1,9 @@
+# This migration comes from community_engine (originally 8)
 class AddFriendshipStatuses < ActiveRecord::Migration
   def self.up
     FriendshipStatus.enumeration_model_updates_permitted = true    
-    FriendshipStatus.create :name => "pending"
-    FriendshipStatus.create :name => "accepted"
+    FriendshipStatus.create({:name => "pending"}, :without_protection => true)
+    FriendshipStatus.create({:name => "accepted"}, :without_protection => true)
     FriendshipStatus.enumeration_model_updates_permitted = false
   end
 

--- a/db/migrate/014_add_states.rb
+++ b/db/migrate/014_add_states.rb
@@ -1,7 +1,8 @@
+# This migration comes from community_engine (originally 14)
 class AddStates < ActiveRecord::Migration
   def self.up
     %w(AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY).each do |s|
-      State.new(:name => s).save
+      State.new({:name => s}, :without_protection => true).save
     end
   end
 

--- a/db/migrate/016_add_metro_areas.rb
+++ b/db/migrate/016_add_metro_areas.rb
@@ -1,3 +1,4 @@
+# This migration comes from community_engine (originally 16)
 class AddMetroAreas < ActiveRecord::Migration
   def self.up
     failed = []
@@ -280,7 +281,7 @@ class AddMetroAreas < ActiveRecord::Migration
 
       next if state.nil?
       
-      ma = MetroArea.new(:name => a[0], :state => state, :country_id => 0)
+      ma = MetroArea.new({:name => a[0], :state => state, :country_id => 0}, :without_protection => true)
       ma.save
     end
     if failed.size > 0

--- a/db/migrate/023_add_denied_friendship_status.rb
+++ b/db/migrate/023_add_denied_friendship_status.rb
@@ -1,7 +1,8 @@
+# This migration comes from community_engine (originally 23)
 class AddDeniedFriendshipStatus < ActiveRecord::Migration
   def self.up
     FriendshipStatus.enumeration_model_updates_permitted = true    
-    FriendshipStatus.create :name => "denied"
+    FriendshipStatus.create({ :name => "denied" }, :without_protection => true)
     FriendshipStatus.enumeration_model_updates_permitted = false
   end
 

--- a/db/migrate/026_add_countries.rb
+++ b/db/migrate/026_add_countries.rb
@@ -1,3 +1,4 @@
+# This migration comes from community_engine (originally 26)
 class AddCountries < ActiveRecord::Migration
   def self.up
     ["Abuja",
@@ -220,7 +221,7 @@ class AddCountries < ActiveRecord::Migration
     "Yemen",
     "Zambia",
     "Zimbabwe"].each do |c|
-      Country.create(:name => c)
+      Country.create({ :name => c }, :without_protection => true)
       end 
   end
 

--- a/db/migrate/056_create_roles.rb
+++ b/db/migrate/056_create_roles.rb
@@ -1,3 +1,4 @@
+# This migration comes from community_engine (originally 56)
 class CreateRoles < ActiveRecord::Migration
   def self.up
     create_table :roles do |t|
@@ -5,9 +6,9 @@ class CreateRoles < ActiveRecord::Migration
     end
 
     Role.enumeration_model_updates_permitted = true
-    Role.create(:name => 'admin')    
-    Role.create(:name => 'moderator')
-    Role.create(:name => 'member')            
+    Role.create({ :name => 'admin' }, :without_protection => true)    
+    Role.create({ :name => 'moderator' }, :without_protection => true)
+    Role.create({ :name => 'member' }, :without_protection => true)            
     Role.enumeration_model_updates_permitted = false
     
     add_column :users, :role_id, :integer


### PR DESCRIPTION
Hi,
I've updated some of the migrations to use the :without_protection option to disable mass assignment protection while inserting data.

This should fix Issue #74, at least partially.

If you want me to change anything about the way I did this, let me know.

Thanks!

-Al
