### PR TITLE
Activation link fix

### DIFF
--- a/app/models/user_notifier.rb
+++ b/app/models/user_notifier.rb
@@ -79,7 +79,7 @@ class UserNotifier < ActionMailer::Base
   def signup_notification(user)
     setup_email(user)        
     @subject    += "#{:please_activate_your_new_account.l(:site => configatron.community_name)}"
-    @url  = "#{home_url}users/activate/#{user.activation_code}"
+    @url  = "#{home_url}users/#{user.activation_code}/activate"
     mail(:to => @recipients, :subject => @subject)
   end
   


### PR DESCRIPTION
Hi,
The initial activation email that goes out to new users appears to have the link back to the activation route in the wrong order.  This should fix it.

-Al
