### PR TITLE
Forum mass assignment fix

### DIFF
--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -40,7 +40,10 @@ class ForumsController < BaseController
 
   def update
     @forum.tag_list = params[:tag_list] || ''
-    @forum.update_attributes!(params[:forum])
+    @forum.name = params[:forum][:name]
+    @forum.position = params[:forum][:position]
+    @forum.description = params[:forum][:description]
+    @forum.save!
     respond_to do |format|
       format.html { redirect_to forums_path }
       format.xml  { head 200 }


### PR DESCRIPTION
I've changed the methods to create/update forum properties to avoid mass assignment restrictions.  I think it makes sense to do it this way, since unprotecting the attributes might allow non-admins to update forum properties somewhere.

Let me know if you like the way I did it or not.  I think there are some other mass assignment bugs around the app, so if you like it fixed this way, I'll keep working :)

-Al
