### PR TITLE
Footer content

### DIFF
--- a/app/views/shared/_end_javascript.html.haml
+++ b/app/views/shared/_end_javascript.html.haml
@@ -5,4 +5,4 @@
 
 -if show_footer_content?        
   :javascript
-    #{remote_function(:update => "footer_content", :url =>  footer_content_url )}
+    #{remote_function(:update => "footer_content", :method => :get, :url =>  footer_content_url )}


### PR DESCRIPTION
Looks like the old remote_function defaults to a post route.  My last pull request (#79) didn't take this into account, so the same error exists.  

I tested locally with a 'match' route then sent you a pull request with the 'get' route in config/routes.rb.  I think 'get' makes the most sense, here -- so I explicitly set the remote function to a get request.

Sorry for the confusion -- still learning my way around github.  My testing was more rigorous this time.

Regards,
Josh
