### PR TITLE
Footer content

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -11,7 +11,7 @@ class BaseController < ApplicationController
   helper_method :commentable_url
   before_filter :initialize_header_tabs
   before_filter :initialize_admin_tabs
-  before_filter :store_location
+  before_filter :store_location, :except => :footer_content
 
   caches_action :site_index, :footer_content, :if => Proc.new{|c| c.cache_action? }
 


### PR DESCRIPTION
This bug popped up after my last pull request, #85.  Now that the :footer_content path is working correctly, the url was being stored for redirection after login.  This pull request fixes that.

I took the suggestion from issue #90, which worked for my testing.
