### PR TITLE
Fix accessible attributes for messages.

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,8 @@
 class Message < ActiveRecord::Base  
   attr_accessor :to
   attr_accessor :reply_to
+
+  attr_accessible :to, :subject, :body
   
   belongs_to :sender,     :class_name => 'User', :foreign_key => 'sender_id', :inverse_of => :sent_messages
   belongs_to :recipient,  :class_name => 'User', :foreign_key => 'recipient_id', :inverse_of => :received_messages


### PR DESCRIPTION
This makes to, subject, and body able to be assigned to from the new and create methods.

Currently trying to send a message results in an error because these attributes cannot be mass assigned to.
