### PR TITLE
When a post is older than 2 days, users are more interested in the date ...

### DIFF
--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -232,9 +232,9 @@ module BaseHelper
     case distance_in_minutes
       when 0              then :a_few_seconds_ago.l
       when 1..59          then :minutes_ago.l(:count => distance_in_minutes)
-      when 60..1440       then :hours_ago.l(:count => (distance_in_minutes.to_f / 60.0).round)
-      when 1440..2880     then :days_ago.l(:count => (distance_in_minutes.to_f / 1440.0).round) # 1.5 days to 2 days
-      else I18n.l(from_time, :format => :time_ago)
+      when 60..1339       then :hours_ago.l(:count => (distance_in_minutes.to_f / 60.0).round)
+      when 1440..2880     then :days_ago.l(:count => (distance_in_minutes.to_f / 1440.0).round) # 1 days to 2 days
+      else I18n.l(from_time.to_date, :format => :published_date)
     end
   end
 


### PR DESCRIPTION
...of the post rather than the time of day it was posted.

See an example of this problem [here](http://circle3.org/forums/6-tech-support/topics/37-time-stamp-of-posts), where you can't tell the dates of the posts.

I also fixed a condition overlap in the case statement.

Thanks for open sourcing this by the way!
