### PR TITLE
Invalid YAML syntax in locales

### DIFF
--- a/config/locales/de-DE.yml
+++ b/config/locales/de-DE.yml
@@ -579,7 +579,7 @@ de-DE:
   #en: joined: joined
   joined: Mitglied seit
   #en: joined_the_site: joined %{site}
-  joined_the_site: %{site} beigetreten
+  joined_the_site: "%{site} beigetreten"
   #en: just_uploading_one_photo: Just uploading one photo?
   just_uploading_one_photo: Nur ein Foto hochladen?
   #en: keywords: Keywords

--- a/config/locales/ru-RU.yml
+++ b/config/locales/ru-RU.yml
@@ -499,7 +499,6 @@ ru-RU:
   #en: event_comments: Event Comments
   event_comments: Комментарии события
   #en: event_does_not_allow_rsvp: This event does not allow SVPs.
-  #ut where to be, and when to be thereuOA
   event_does_not_allow_rsvp: Это событие не разрешает приглашения.
   #en: event_was_successfully_created: Event was successfully created.
   event_was_successfully_created: Событие были успешно создано.


### PR DESCRIPTION
communityengine fails to run with JRuby 1.9.3 because of invalid yaml.

de-DE.yml: % cannot start a scalar => http://pyyaml.org/ticket/63
ru-RU.yml: 0x1B is a special character; special characters are not allowed
