### PR TITLE
Seperate existing tags by comma when editing user profile.

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -52,7 +52,7 @@
       -box do 
         %h3= :tags.l
         #user_tags
-          = text_field_tag 'tag_list', @user.tag_list, {:autocomplete => "off"}
+          = text_field_tag 'tag_list', @user.tag_list.join(", "), {:autocomplete => "off"}
           #tag_list_auto_complete.auto_complete
           -content_for :end_javascript do
             = auto_complete_field 'tag_list', {:url => { :controller => "tags", :action => 'auto_complete_for_tag_name'}, :tokens => [','] }


### PR DESCRIPTION
When editing a user profile, existing tags will not be comma-seperated in the input field, so they will be overwritten when changes are saved.

This PR solves this issue by maintaining comma-seperation for the tags when displayed on the edit profile page.
