### PR TITLE
Allow sending messages to lower case recipients.

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -45,8 +45,8 @@ class MessagesController < BaseController
       @message.valid?
       render :action => :new and return
     else
-      @message = Message.new(params[:message])          
-      @message.recipient = User.find_by_login(params[:message][:to].strip)
+      @message = Message.new(params[:message])
+      @message.recipient= User.where('lower(login) = ?', params[:message][:to].strip).first
       @message.sender = @user
       unless @message.valid?
         render :action => :new and return        


### PR DESCRIPTION
When sending a private message, the to param and the input field are populated by a recipient name which is lower case regardless of the original name. If the name is not all lower-case in the database, the message will fail to send with the error "Recipient is invalid".

This PR fixes it by making a case-insensitive search on the Rails model.
