### PR TITLE
Force downcase on message recipient param.

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -46,7 +46,7 @@ class MessagesController < BaseController
       render :action => :new and return
     else
       @message = Message.new(params[:message])
-      @message.recipient= User.where('lower(login) = ?', params[:message][:to].strip).first
+      @message.recipient= User.where('lower(login) = ?', params[:message][:to].strip.downcase).first
       @message.sender = @user
       unless @message.valid?
         render :action => :new and return        


### PR DESCRIPTION
Apologies for my previous oversight in PR #138. We didn't make it truly case-insensitive because we didn't force downcase on the recipient "to" param, so if the user would type in the name manually, e.g. "JohnSmith" it would fail.

This should be good now.
