### PR TITLE
Fix admin pages public status display.

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -25,10 +25,10 @@
                 = link_to page.title, edit_admin_page_path(page)
                 = link_to("(#{:preview.l})", preview_admin_page_path(page), :target => '_blank') unless page.is_live?
               %td
-                -if page.is_public? 
-                  = t(:yes)
+                -if page.page_public? 
+                  = t(:yes_status)
                 -else
-                  = t(:no)
+                  = t(:no_status)
               %td= page.is_live? ? link_to(:published.l, pages_path(page)) : :draft.l
         
       =paginate @pages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -922,9 +922,9 @@ en:
   #en: optional_keywords_describing_this_topic_separated_by_commas: optional keywords describing this topic, separated by commas
   optional_keywords_describing_this_topic_separated_by_commas: optional keywords describing this topic, separated by commas
   #en: yes_status: yes
-  yes: yes
+  yes_status: "yes"
   #en: no_status: no
-  no: no
+  no_status: "no"
   #en: or: or
   or: or
   #en: page: page


### PR DESCRIPTION
In the admin / pages section, Public would always report "No" and show translation missing error. Fix this by:
1. Avoid using YAML reserved words and change yes to `yes_status` and no to `no_status`.
2. There's no `is_public` in the page model, it's `page_public`.
