### PR TITLE
Transform tag_list into tag string suitable for editing.

### DIFF
--- a/app/views/clippings/edit.html.haml
+++ b/app/views/clippings/edit.html.haml
@@ -18,7 +18,7 @@
         %label
           =:tags.l
           %em="(#{:optional_keywords_describing_this_clipping_separated_by_commas.l})"
-        = text_field_tag 'tag_list', @clipping.tag_list
+        = text_field_tag 'tag_list', @clipping.tag_list.to_s
 
         %p
           = submit_tag :save.l

--- a/app/views/forums/_form.html.haml
+++ b/app/views/forums/_form.html.haml
@@ -12,7 +12,7 @@
       %label
         =:tags.l
         %em="(#{:optional_keywords_describing_this_forum_separated_by_commas.l})"
-      = text_field_tag 'tag_list', @forum.tag_list, {:autocomplete => "off", :size => 35}
+      = text_field_tag 'tag_list', @forum.tag_list.to_s, {:autocomplete => "off", :size => 35}
       #tag_list_auto_complete.auto_complete
       
       -content_for :end_javascript do

--- a/app/views/photos/edit.html.haml
+++ b/app/views/photos/edit.html.haml
@@ -22,7 +22,7 @@
       %label 
         = :tags.l
         %em="(#{:optional_keywords_describing_this_photo_separated_by_commas.l})"
-      = text_field_tag 'tag_list', @photo.tag_list.join(', '), {:autocomplete => "off", :size => 35}
+      = text_field_tag 'tag_list', @photo.tag_list.to_s, {:autocomplete => "off", :size => 35}
       #tag_list_auto_complete.auto_complete{"class"=>"auto_complete"} 
       -content_for :end_javascript do
         = auto_complete_field 'tag_list', {:url => { :controller => "tags", :action => 'auto_complete_for_tag_name'}, :tokens => [','] }

--- a/app/views/topics/_form.html.haml
+++ b/app/views/topics/_form.html.haml
@@ -13,7 +13,7 @@
 %label
   = :tags.l
   %em="(#{:optional_keywords_describing_this_topic_separated_by_commas.l})"
-= text_field_tag 'tag_list', @topic.tag_list, {:autocomplete => "off", :size => 35}
+= text_field_tag 'tag_list', @topic.tag_list.to_s, {:autocomplete => "off", :size => 35}
 #tag_list_auto_complete.auto_complete
 
 -content_for :end_javascript do

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -52,7 +52,7 @@
       -box do 
         %h3= :tags.l
         #user_tags
-          = text_field_tag 'tag_list', @user.tag_list.join(", "), {:autocomplete => "off"}
+          = text_field_tag 'tag_list', @user.tag_list.join.to_s, {:autocomplete => "off"}
           #tag_list_auto_complete.auto_complete
           -content_for :end_javascript do
             = auto_complete_field 'tag_list', {:url => { :controller => "tags", :action => 'auto_complete_for_tag_name'}, :tokens => [','] }


### PR DESCRIPTION
From `acts_as_taggable_on` documentation, using `to_s` is the proper way to have `tag_list` input fields maintain comma-separation when editing.
