### PR TITLE
update gemspec to fix configatron errors

### DIFF
--- a/community_engine.gemspec
+++ b/community_engine.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency(%q<rack>, [">= 1.4.1"])
   s.add_dependency(%q<authlogic>, [">= 0"])
   s.add_dependency(%q<bcrypt-ruby>, [">= 0"])
-  s.add_dependency(%q<configatron>, [">= 0"])
+  s.add_dependency(%q<configatron>, ["~> 2.0"])
   s.add_dependency(%q<hpricot>, [">= 0"])
   s.add_dependency(%q<htmlentities>, [">= 0"])
   s.add_dependency(%q<haml>, [">= 0"])


### PR DESCRIPTION
Fixes errors by forcing configatron version.  A quick fix until CommunityEngine is updated to work with the new version of configatron.
