### PR TITLE
fix some links on admin messages page

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -23,7 +23,7 @@ class MessagesController < BaseController
   end
   
   def show
-    @message = Message.read(params[:id], current_user)
+    @message = Message.read(params[:id], @user)
     @message_thread = MessageThread.for(@message, (admin? ? @message.recipient : current_user ))
     @reply = Message.new_reply(@user, @message_thread, params)    
   end

--- a/app/views/messages/_sent.html.haml
+++ b/app/views/messages/_sent.html.haml
@@ -18,11 +18,11 @@
                   .photo= link_to image_tag( message.recipient.avatar_photo_url(:thumb), "height"=>"50px", "alt"=>"#{message.recipient.login}", "width"=>"50px" ), user_path(message.recipient), :title => :users_profile.l(:user => message.recipient.login)
 
                 %td
-                  = link_to h(message.subject), user_message_path(@user, message)                  
+                  = link_to h(message.subject), user_message_path(message.sender, message)
                   %br
                   = :to.l 
                   \:
-                  = link_to h(message.recipient.login), user_path(@user)                  
+                  = link_to h(message.recipient.login), user_path(message.recipient)
                 %td.meta{:width => '150px'}
                   = time_ago_in_words_or_date(message.created_at)                                  
             


### PR DESCRIPTION
Some links on the sent messages page caused a crash when trying to view as an admin.
