### PR TITLE
fixed db:migate error in postgres

### DIFF
--- a/db/migrate/039_create_activities_table.rb
+++ b/db/migrate/039_create_activities_table.rb
@@ -1,9 +1,9 @@
 class CreateActivitiesTable < ActiveRecord::Migration
   def self.up
     create_table :activities do |t|
-      t.column :user_id, :integer, :limit => 10
+      t.column :user_id, :integer
       t.column :action, :string, :limit => 50
-      t.column :item_id, :integer, :limit => 10
+      t.column :item_id, :integer
       t.column :item_type, :string
       t.column :created_at, :datetime
     end


### PR DESCRIPTION
Error occurred when pushed to Heroku using postgres

> No integer type has byte size 10. Use a numeric with precision 0 
> app/db/migrate/20140311064937_create_activities_table.community_engine.rb:4:in `up'

```
An error has occurred, this and all later migrations canceled:

No integer type has byte size 10. Use a numeric with precision 0 instead./app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/postgresql/schema_statements.rb:457:in `type_to_sql'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract_adapter.rb:165:in `type_to_sql'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract_adapter.rb:134:in `visit_ColumnDefinition'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/postgresql/schema_statements.rb:14:in `visit_ColumnDefinition'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract_adapter.rb:117:in `accept'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract_adapter.rb:143:in `block in visit_TableDefinition'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract_adapter.rb:143:in `map'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract_adapter.rb:143:in `visit_TableDefinition'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract_adapter.rb:117:in `accept'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:190:in `create_table'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:625:in `block in method_missing'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:597:in `block in say_with_time'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:597:in `say_with_time'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:617:in `method_missing'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:383:in `method_missing'
/app/db/migrate/20140311064937_create_activities_table.community_engine.rb:4:in `up'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:534:in `up'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:574:in `exec_migration'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:555:in `block (2 levels) in migrate'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:554:in `block in migrate'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:553:in `migrate'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:709:in `migrate'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:959:in `block in execute_migration_in_transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:1005:in `block in ddl_transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract/database_statements.rb:202:in `block in transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract/database_statements.rb:210:in `within_new_transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract/database_statements.rb:202:in `transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/transactions.rb:209:in `transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:1005:in `ddl_transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:958:in `execute_migration_in_transaction'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:920:in `block in migrate'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:916:in `each'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:916:in `migrate'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:764:in `up'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/migration.rb:742:in `migrate'
/app/vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.3/lib/active_record/railties/databases.rake:42:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```
