### PR TITLE
postgres does not like nil in datetime field

### DIFF
--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -7,7 +7,7 @@ message_from_kevin_to_aaron:
   recipient_deleted: false
   subject: Test message
   body: Test body
-  read_at: <%= 1.days.ago.iso8601 %>
+  read_at:
   created_at: <%= 2.days.ago.iso8601 %>
   updated_at: <%= 2.days.ago.iso8601 %>
 message_from_aaron_to_leopoldo:
@@ -18,7 +18,7 @@ message_from_aaron_to_leopoldo:
   recipient_deleted: true
   subject: Test message
   body: Test body
-  read_at: <%= 1.days.ago.iso8601 %>
+  read_at:
   created_at: <%= 2.days.ago.iso8601 %>
   updated_at: <%= 2.days.ago.iso8601 %>
 


### PR DESCRIPTION
fix in fixtures/messages.yml

```
PG::InvalidDatetimeFormat: ERROR:  invalid input syntax for type timestamp: "nil"
LINE 1: ... (1, 3, 2, 'f', 'f', 'Test message', 'Test body', 'nil', '20...
                                                             ^
: INSERT INTO "messages" ("id", "sender_id", "recipient_id", "sender_deleted", "recipient_deleted", "subject", "body", "read_at", "created_at", "updated_at") VALUES (1, 3, 2, 'f', 'f', 'Test message', 'Test body', 'nil', '2014-03-11 01:06:30.000000', '2014-03-11 01:06:30.000000')
```
