### PR TITLE
Specifying license as MIT, noting licenses of plugins

### DIFF
--- a/community_engine.gemspec
+++ b/community_engine.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary = "CommunityEngine for Rails 3"
   s.description = "CommunityEngine is a free, open-source social network platform for Ruby on Rails applications. Drop it into your new or existing application, and you’ll instantly have all the features of a basic community site."
   s.homepage = "http://www.communityengine.org"
+  s.licenses = ["MIT", "see each plugin"]
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["Bruno Bornsztein"]


### PR DESCRIPTION
Closes #152

Per LICENSE

The "CommunityEngine" plugin is distributed under the MIT license (which
is the same license that Ruby on Rails is distributed under). This license
does not include any code found in the "community_engine/plugins" directory. Those plugins
are each licensed individually and their licenses should be reviewed before
you use this application. Most plugins are also licensed under the MIT
license, but some may not be. If a plugin does not
have a license, due diligence should be taken to find the license on the
plugin's website.
