### PR TITLE
Sprockets fix for Bootstrap.

### DIFF
--- a/app/assets/javascripts/community_engine.js
+++ b/app/assets/javascripts/community_engine.js
@@ -5,7 +5,7 @@
 //= require jquery.migrate
 //= require jquery_ujs
 //= require jquery-ui
-//= require bootstrap
+//= require bootstrap-sprockets
 //
 ///////////////////////////////////////////
 // UTILITIES                             //

--- a/app/assets/stylesheets/_layout.css.scss
+++ b/app/assets/stylesheets/_layout.css.scss
@@ -1,3 +1,4 @@
+@import 'bootstrap-sprockets';
 @import 'bootstrap';
 
 body {


### PR DESCRIPTION
Use proper sass and javascript includes for bootstrap-sass gem.  Fixes glyphicons not showing up (among other things).
