### PR TITLE
Asset pipeline fix for ajax spinner image.

### DIFF
--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -276,7 +276,7 @@ module BaseHelper
   end
 
   def ajax_spinner_for(id, spinner="spinner.gif")
-    "<img src='/assets/#{spinner}' class='hide' id='#{id.to_s}_spinner'> ".html_safe
+    image_tag spinner, :class => 'hide', :id => id + '_spinner'
   end
 
   def avatar_for(user, size=32)


### PR DESCRIPTION
Fixes some "404 not found" errors by replacing raw html with `image_tag`.
