### PR TITLE
Fix time and date format in time_ago_in_words

### DIFF
--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -314,7 +314,7 @@ module BaseHelper
       when 1..59          then :minutes_ago.l(:count => distance_in_minutes)
       when 60..1440       then :hours_ago.l(:count => (distance_in_minutes.to_f / 60.0).round)
       when 1440..2880     then :days_ago.l(:count => (distance_in_minutes.to_f / 1440.0).round) # 1.5 days to 2 days
-      else I18n.l(from_time, :format => :time_ago)
+      else I18n.l(from_time, :format => :short)
     end
   end
 
@@ -324,7 +324,7 @@ module BaseHelper
     elsif date.to_date.eql?(Time.now.to_date - 1)
       display = :yesterday.l
     else
-      display = I18n.l(date.to_date, :format => :date_ago)
+      display = I18n.l(date.to_date, :format => :short)
     end
   end
 


### PR DESCRIPTION
Fixes issue #205 and adds day to `time_ago_in_words_or_date` format (previously showed only month and year).
