### PR TITLE
show blog posts from active users only

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,6 +32,8 @@ class Post < ActiveRecord::Base
 
   attr_accessor :invalid_emails
 
+  default_scope -> {includes(:user).where('users.activated_at IS NOT NULL')}
+
   # Class Methods
   class << self
 


### PR DESCRIPTION
otherwise, an error will be thrown if trying to access blog posts by a deactivated user
