### PR TITLE
Remove dependency on master branch of acts_as_commentable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 gem 'omniauth-facebook'
-gem 'acts_as_commentable', :git => 'https://github.com/jackdempsey/acts_as_commentable'
 
 group :test do
   gem 'sqlite3'

--- a/community_engine.gemspec
+++ b/community_engine.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency(%q<friendly_id>, ["~> 3.3"])
   s.add_dependency(%q<paperclip>, ["~> 3.5.1"])
   s.add_dependency(%q<cocaine>, ["~> 0.5.1"])
-  s.add_dependency(%q<acts_as_commentable>, ["~> 4.0.1"])
+  s.add_dependency(%q<acts_as_commentable>, ["~> 4.0.2"])
   s.add_dependency(%q<recaptcha>, [">= 0"])
   s.add_dependency(%q<omniauth>, ["~> 1.1.0"])
   s.add_dependency(%q<prototype-rails>, [">= 0"])


### PR DESCRIPTION
Change to new version of acts_as_commentable gem, rather than use its master branch.  Fixes #226.
