### PR TITLE
Remove dependency on master branch of acts_as_commentable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 gem 'omniauth-facebook'
-gem 'acts_as_commentable', :git => 'https://github.com/jackdempsey/acts_as_commentable'
 
 group :test do
   gem 'sqlite3'

--- a/community_engine.gemspec
+++ b/community_engine.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "actionpack-action_caching", ">= 0"
   s.add_dependency "actionpack-page_caching",   ">= 0"
-  s.add_dependency "acts_as_commentable",       "~> 4.0.1"
+  s.add_dependency "acts_as_commentable",       "~> 4.0.2"
   s.add_dependency "acts_as_list",              ">= 0.3.0"
   s.add_dependency "acts-as-taggable-on",       '~> 2.4.1'
   s.add_dependency "authlogic",                 ">= 3.3.0"


### PR DESCRIPTION
Change to new version of acts_as_commentable gem, rather than use its master branch.  Fixes #226.
