### PR TITLE
removed /assets prefix from image; bugfix tags; bugfix toggle actions

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -40,9 +40,9 @@ class TagsController < BaseController
 
   def update
     @tag = ActsAsTaggableOn::Tag.find_by_name(URI::decode(params[:id]))
-
+    
     respond_to do |format|
-      if @tag.update_attributes(params[:tag])
+      if @tag.update_attributes(params[:tag].permit(:name))
         flash[:notice] = :tag_was_successfully_updated.l
         format.html { redirect_to admin_tags_url }
         format.xml  { render :nothing => true }

--- a/app/views/events/_subscribe.html.haml
+++ b/app/views/events/_subscribe.html.haml
@@ -2,6 +2,6 @@
   %h3= :subscribe_to.l + ' ' + :events.l
   %p= :subscribe_events_instructions.l
   .icon_row
-    = link_to image_tag('/assets/icons/ical.gif'), ical_events_url(:protocol => 'webcal://', :format=>'ics')
+    = link_to image_tag('icons/ical.gif'), ical_events_url(:protocol => 'webcal://', :format=>'ics')
     = link_to image_tag("http://www.google.com/calendar/images/ext/gc_button1.gif"), "http://www.google.com/calendar/render?cid=#{ical_events_url(:format=>'ics')}", :target=>'_blank'
 

--- a/app/views/users/_profile_user_info_sidebar.html.haml
+++ b/app/views/users/_profile_user_info_sidebar.html.haml
@@ -42,6 +42,6 @@
     %ul.list-unstyled
       %li= link_to(:assume_user_id.l, assume_user_path(@user), {:method => :post} )
       %li= link_to(:delete_this_user.l, user_path(@user), {:method => :delete, data: { confirm: :are_you_sure_you_want_to_permanently_delete_this_user.l }} )
-      %li= link_to("#{:toggle.l} #{:featured_writer.l}".html_safe, toggle_featured_user_path(@user), {:method => :put} )
-      %li= link_to("#{:assign_role.l}: #{@user.moderator? ? :member.l : :moderator.l}".html_safe, toggle_moderator_user_path(@user), {:method => :put} )
+      %li= link_to("#{:toggle.l} #{:featured_writer.l}".html_safe, toggle_featured_user_path(@user), {:method => :patch} )
+      %li= link_to("#{:assign_role.l}: #{@user.moderator? ? :member.l : :moderator.l}".html_safe, toggle_moderator_user_path(@user), {:method => :patch} )
 

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -8,7 +8,6 @@ class TagsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-
   def test_should_show_tag
    get :show, :id => tags(:general).name
    assert_response :success
@@ -30,7 +29,6 @@ class TagsControllerTest < ActionController::TestCase
      assert_response :success
    end
   end
-  
 
   def test_should_fail_to_show_tag
    get :show, :id => 'tag_that_does_not_exist'
@@ -41,7 +39,6 @@ class TagsControllerTest < ActionController::TestCase
    get :index
    assert_response :success
   end
-  
   
   test "should get manage as admin" do
     login_as :admin
@@ -55,8 +52,6 @@ class TagsControllerTest < ActionController::TestCase
     assert_response :redirect
   end  
 
-  
-  
   def test_should_show_matching_items_for_multiple_tags
     posts(:apt_post).tag_list = "#{tags(:general).name},#{tags(:extra).name}"
     posts(:apt_post).save
@@ -68,5 +63,15 @@ class TagsControllerTest < ActionController::TestCase
     assert_equal 2, assigns(:posts).size
     assert assigns(:posts).include?(posts(:apt_post))
     assert assigns(:posts).include?(posts(:apt2_post))
+  end
+  
+  def test_should_update_tag
+    posts(:apt_post).tag_list = "#{tags(:general).name},#{tags(:extra).name}"
+    posts(:apt_post).save
+    
+    login_as :admin
+    patch :update, :id => posts(:apt_post).tags.first.name, :tag => {:name => 'changed name' }
+    assert_equal assigns(:tag).name, "changed name"
+    assert_redirected_to admin_tags_path
   end
 end

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -66,12 +66,12 @@ class TagsControllerTest < ActionController::TestCase
   end
   
   def test_should_update_tag
-    posts(:apt_post).tag_list = "#{tags(:general).name},#{tags(:extra).name}"
+    posts(:apt_post).tag_list = "hansel"
     posts(:apt_post).save
     
     login_as :admin
-    patch :update, :id => posts(:apt_post).tags.first.name, :tag => {:name => 'changed name' }
-    assert_equal assigns(:tag).name, "changed name"
+    patch :update, :id => "hansel", :tag => {:name => 'gretel' }
+    assert_equal assigns(:tag).name, "gretel"
     assert_redirected_to admin_tags_path
   end
 end


### PR DESCRIPTION
1) removed /assets prefix from image
2) bugfix: admin tags update permit was missing
3) bugfix: profile-user-sidebar toggle actions patch instead of put