### PR TITLE
fixed comments html anchors + fixed rss feeds

### DIFF
--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -7,12 +7,12 @@ module BaseHelper
   def commentable_url(comment)
     if comment.recipient && comment.commentable
       if comment.commentable_type != "User"
-        polymorphic_url([comment.recipient, comment.commentable])+"#comment_#{comment.id}"
+        polymorphic_url([comment.recipient, comment.commentable])+"#comment-#{comment.id}"
       elsif comment
-        user_url(comment.recipient)+"#comment_#{comment.id}"
+        user_url(comment.recipient)+"#comment-#{comment.id}"
       end
     elsif comment.commentable
-      polymorphic_url(comment.commentable)+"#comment_#{comment.id}"
+      polymorphic_url(comment.commentable)+"#comment-#{comment.id}"
     end
   end
 

--- a/app/views/comments/approve.js.haml
+++ b/app/views/comments/approve.js.haml
@@ -1,1 +1,1 @@
-$$('#comment_#{@comment.id} .approve a').invoke('hide');
+$$('#comment-#{@comment.id} .approve a').invoke('hide');

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -65,7 +65,7 @@
         %dd
           = truncate_words(comment.comment, 10).html_safe
           %br
-          = link_to "&raquo; ".html_safe + :view_comment.l, user_photo_path(@user, comment.commentable) + "#comment_#{comment.id}"
+          = link_to "&raquo; ".html_safe + :view_comment.l, user_photo_path(@user, comment.commentable) + "#comment-#{comment.id}"
 
 - unless @photos.empty?
   .clearfix

--- a/lib/resource_feeder/atom.rb
+++ b/lib/resource_feeder/atom.rb
@@ -1,3 +1,5 @@
+require "builder"
+
 module ResourceFeeder
   module Atom
     extend self

--- a/lib/resource_feeder/rss.rb
+++ b/lib/resource_feeder/rss.rb
@@ -1,3 +1,5 @@
+require "builder"
+
 module ResourceFeeder
   module Rss
     extend self

--- a/test/functional/comments_controller_test.rb
+++ b/test/functional/comments_controller_test.rb
@@ -85,6 +85,13 @@ class CommentsControllerTest < ActionController::TestCase
     assert_response :success
     assert !assigns(:comments).empty?
   end
+  
+  def test_should_show_comments_index_rss_on_user_profile
+    login_as :quentin
+    get :index, :commentable_type => 'users', :commentable_id => users(:aaron).login, :format => 'rss'
+    assert_response :success
+    assert !assigns(:comments).empty?
+  end
 
   def test_should_show_empty_comments_index
     login_as :aaron


### PR DESCRIPTION
1) There was a "_" and "-" mishmash..now it´s cleaned up and works again. - comments html anchors
2) Fixed rss feeds - if you only execute one test-file (for example: comments_controller_test.rb) you can see the error - if everything gets executed the "builder" gem is required somewhere and it works.. I explicit required the builder gem now in the rss and atom class to fix this issue.