### PR TITLE
hard links changed to helper routes for deploying to subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ test/testapp/public/system/
 coverage
 bin/
 
+.idea/
+
 pkg
 *.gem

--- a/app/views/shared/_login_sidebar.html.haml
+++ b/app/views/shared/_login_sidebar.html.haml
@@ -4,7 +4,7 @@
   %p
     =:dont_have_an_account.l
     %br
-    = link_to :click_here_to_sign_up.l, "/signup"
+    = link_to :click_here_to_sign_up.l, signup_path
   %p
     =:forgot_your_password.l
     %br

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -12,7 +12,7 @@
     =:after_signing_up_youll_receive_an_e_mail_confirmation_message.l
   %p
     =:click_the_activation_link_in_the_e_mail_to_log_in.l
-  %p= link_to :already_have_an_account.l, "/login"
+  %p= link_to :already_have_an_account.l,  login_path
 
 
 = bootstrap_form_for @user, :layout => :horizontal do |f|

--- a/app/views/users/signup_completed.html.haml
+++ b/app/views/users/signup_completed.html.haml
@@ -5,4 +5,4 @@
   %li= :see_you_back_here_in_a_short_while.l        
 
 %h2= :no_activation_email.l
-= button_to :resend_my_activation_e_mail.l, "/resend_activation?id=#{@user.to_param}", :class => 'btn btn-primary'
+= button_to :resend_my_activation_e_mail.l, resend_activation_path(@user.to_param), :class => 'btn btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
     get '(page/:page)', :action => :index, :on => :collection
   end
 
+
+
+
+
   get '/base/:action' => 'base'
 
   get '/forums/recent' => 'sb_posts#index', :as => :recent_forum_posts
@@ -76,7 +80,7 @@ Rails.application.routes.draw do
 
   match '/forgot_username' => 'users#forgot_username', :as => :forgot_username, :via => [:get, :post]
 
-  post '/resend_activation' => 'users#resend_activation', :as => :resend_activation
+  post '/resend_activation/:id' => 'users#resend_activation', :as => :resend_activation
 
   get '/new_clipping' => 'clippings#new_clipping'
   post '/load_images_from_uri' => 'clippings#load_images_from_uri', :format => 'js'


### PR DESCRIPTION
Deploying to sub-directories resulted in paths being directed to the root instead of the base uri. 

When base uri is set via any of various methods such as "PassengerBaseURI /communityengine"

Link "signup" should point to "/communityengine/signup" but was pointing to "/signup"


