### PR TITLE
Update README to include alternative installation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,6 +61,12 @@ Getting CommunityEngine Running
   $ bin/rails server
   ```
 
+Alternative installation
+------------------------
+
+For a user with difficulty. Try
+https://github.com/taro-k/ce_base
+
 Optional Configuration
 ----------------------
 


### PR DESCRIPTION
Hi, I hope the user base of CE will expand more and more. As digging web, we can find several user faces installation difficulty like:
http://stackoverflow.com/questions/29324964/install-community-engine-on-rails-4-2-1

So, I made small repo to help as alternative installation method. I am happy if you update README with this.
